### PR TITLE
Git triggers source install on ref change

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -6,13 +6,6 @@
 working_path = "#{Chef::Config[:file_cache_path]}/elixir"
 
 #------- codes -------
-git "elixir" do
-  repository  node[:elixir][:source][:repo]
-  revision    node[:elixir][:source][:revision]
-  destination working_path
-  action :sync
-end
-
 bash "install" do
   cwd working_path
   code <<-EOH
@@ -20,6 +13,13 @@ bash "install" do
     make
     make install PREFIX='#{node[:elixir][:install_path]}'
     EOH
-  action :run
-  not_if 'which elixir'
+  action :nothing #Let git trigger install
+end
+
+git "elixir" do
+  repository  node[:elixir][:source][:repo]
+  revision    node[:elixir][:source][:revision]
+  destination working_path
+  action :sync
+  notifies :run, "bash[install]", :immediately
 end


### PR DESCRIPTION
If revision changes install would never trigger. This now relies on git to trigger the install.
